### PR TITLE
Enable CMake parallel build

### DIFF
--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -292,7 +292,9 @@ else
 fi
 mkdir -p "${cmake_install_dir}"
 
-cmake_max_jobs="${max_jobs:-1}"
+if [ -v max_jobs ]; then
+  export CMAKE_BUILD_PARALLEL_LEVEL=${max_jobs}
+fi
 
 #
 # 5. CMake configure
@@ -322,7 +324,7 @@ message "== CMAKE GENERATE PROJECT finished"
 # 6. CMake build and install
 #
 message "CMAKE build:"
-message "cmake --build ${cmake_build_dir} --parallel ${cmake_max_jobs} |& tee -a $build_log"
+message "cmake --build ${cmake_build_dir} |& tee -a $build_log"
 message "== CMAKE BUILD start"
 cmake --build ${cmake_build_dir} |& tee -a $build_log
 message "== CMAKE BUILD finished"

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -320,7 +320,7 @@ message "== CMAKE GENERATE PROJECT finished"
 message "CMAKE build:"
 message "cmake --build ${cmake_build_dir} |& tee -a $build_log"
 message "== CMAKE BUILD start"
-cmake --build ${cmake_build_dir} |& tee -a $build_log
+cmake --build ${cmake_build_dir} --parallel 4 |& tee -a $build_log
 message "== CMAKE BUILD finished"
 
 message "CMAKE install:"

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -320,7 +320,7 @@ message "== CMAKE GENERATE PROJECT finished"
 message "CMAKE build:"
 message "cmake --build ${cmake_build_dir} |& tee -a $build_log"
 message "== CMAKE BUILD start"
-cmake --build ${cmake_build_dir} --parallel 4 |& tee -a $build_log
+cmake --build ${cmake_build_dir} |& tee -a $build_log
 message "== CMAKE BUILD finished"
 
 message "CMAKE install:"

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -33,6 +33,7 @@ function help_tsmp2() {
   echo "  --install_dir    Set install dir cmake, if not set bin/<SYSTEMNAME>_<model-id> is used. Model executables and libraries will be installed here"
   echo "  --clean_first    Delete build_dir if it already exists"
   echo "  --env            Set model environment."
+  echo "  --max_jobs       Set the maximum number of jobs to build the code, if not set compilation is serial."
   echo ""
   echo "Example: $0 --ICON --eCLM --ParFlow"
   exit 1
@@ -124,6 +125,7 @@ while [[ "$#" -gt 0 ]]; do
     --build_dir) build_dir="$2"; shift ;;
     --install_dir) install_dir="$2"; shift ;;
     --env) env="$2"; shift ;;
+    --max_jobs) max_jobs="$2"; shift ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
@@ -290,6 +292,8 @@ else
 fi
 mkdir -p "${cmake_install_dir}"
 
+cmake_max_jobs="${max_jobs:-1}"
+
 #
 # 5. CMake configure
 #
@@ -318,7 +322,7 @@ message "== CMAKE GENERATE PROJECT finished"
 # 6. CMake build and install
 #
 message "CMAKE build:"
-message "cmake --build ${cmake_build_dir} |& tee -a $build_log"
+message "cmake --build ${cmake_build_dir} --parallel ${cmake_max_jobs} |& tee -a $build_log"
 message "== CMAKE BUILD start"
 cmake --build ${cmake_build_dir} |& tee -a $build_log
 message "== CMAKE BUILD finished"


### PR DESCRIPTION
For components using the CMake build tool; tested with ParFlow.

Four threads appears to be the sweet spot.  Walltimes (ParFlow only):

-j 1 -> 164 s
-j 2 -> 100 s
-j 4 ->  64 s
-j 8 ->  50 s