### PR TITLE
Support GNU+ParaStationMPI toolchain

### DIFF
--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -17,8 +17,8 @@ function help_tsmp2() {
   echo "  --version        Print $0 scipt version"
   echo "  --ICON           Compile with ICON"
   echo "  --eCLM           Compile with eCLM"
-  echo "  --ParFlow        Compile with ParFlow"
-  echo "  --ParFlowGPU    Compile with ParFlow-GPU"
+  echo "  --ParFlow        Compile with ParFlow (CPU mode)"
+  echo "  --ParFlowGPU     Compile with ParFlow (GPU mode)"
   echo "  --PDAF           Compile with PDAF"
   echo "  --COSMO          Compile with COSMO"
   echo "  --CLM35          Compile with CLM3.5"
@@ -106,8 +106,8 @@ while [[ "$#" -gt 0 ]]; do
     --version) echo "$0 version 0.1.0"; exit 0;;
     --icon) icon=y;;
     --eclm) eclm=y;;
-    --parflow) parflow=y parflowGPU=n;;
-    --parflowgpu) parflow=y parflowGPU=y;;
+    --parflow) parflow=y; parflowCPU=y; parflowCMakeModelID="ParFlow" ;;
+    --parflowgpu) parflow=y; parflowGPU=y; parflowCMakeModelID="ParFlowGPU" ;;
     --pdaf) pdaf=y;;
     --cosmo) cosmo=y;;
     --clm35) clm35=y;;
@@ -141,8 +141,7 @@ message "Setting model-id and component string..."
 # fun set_component shell_name cmake_name
 set_component icon "ICON"
 set_component eclm "eCLM"
-set_component parflow "ParFlow"
-set_component parflowGPU "ParFlowGPU" #TODO: check if only one ParFlow option is enabled (either --parflow or --parflowgpu)
+set_component parflow $parflowCMakeModelID
 set_component cosmo "COSMO"
 set_component clm35 "CLM3.5"
 set_component pdaf "PDAF"
@@ -152,6 +151,11 @@ if [ $model_count = 0 ];then
   exit 1
 elif [ $model_count -ge 2 ];then
   oasis=y
+fi
+
+if [[ "${parflowCPU}" == "y" &&  "${parflowGPU}" == "y" ]];then
+  echo "ABORT: Building --parflow and --parflowgpu at the same time is not supported."
+  exit 1
 fi
 
 ## CONCATENATE SOURCE CODE STRING

--- a/env/jsc.2025.gnu.psmpi
+++ b/env/jsc.2025.gnu.psmpi
@@ -1,0 +1,75 @@
+# --------------------------------------------------------------------------
+# Loads GNU+ParaStationMPI build environment for TSMP2.
+# This environment is tailored for JURECA [1] and JUWELS [2] supercomputers.
+#
+# [1] https://apps.fz-juelich.de/jsc/software/jureca/index.xhtml
+# [2] https://apps.fz-juelich.de/jsc/software/juwels/index.xhtml
+# 
+# Usage: source jsc.2025.gnu.psmpi
+# --------------------------------------------------------------------------
+
+# Load Stages/2025
+module --force purge
+module use $OTHERSTAGES
+module load Stages/2025
+
+# Primary compiler toolchain
+module load GCC
+module load ParaStationMPI
+
+# Basic scripting and build tools
+module load Python
+module load CMake
+module load git
+
+# Storage libraries
+module load HDF5
+module load netCDF
+module load netCDF-Fortran
+module load PnetCDF
+
+# ParFlow additional libraries
+if [[ "$1" == "--parflowgpu" ]]; then
+  module load CUDA
+  module load UCX-settings/RC-CUDA
+  module load Hypre/2.31.0
+
+  # TODO: Verify these values
+  if [[ $SYSTEMNAME == "jedi" || $SYSTEMNAME == "jupiter" ]]; then
+    export CUDAARCHS="90"
+  else
+    export CUDAARCHS="80"
+  fi
+  export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
+else
+  module load Hypre/2.31.0-cpu
+fi
+module load Tcl
+
+# ICON additional libraries
+module load ecCodes
+
+# Set default MPI compilers
+export OMPI_CC=gcc
+export OMPI_CXX=g++
+export OMPI_FC=gfortran
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+export MPI_HOME=$EBROOTPSMPI
+
+# Display compiler settings
+module list
+echo "=============== COMPILER SETTINGS  ===============" 
+echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
+echo "   MPI lib: $(mpichversion | head -n 1 | tr -d =)"
+echo "         C: $($CC --version | head -n 1)"
+echo "       C++: $($CXX --version | head -n 1)"
+echo "   Fortran: $($FC --version | head -n 1)"
+if [[ "$1" == "--parflowgpu" ]]; then
+  echo "      nvcc: $(nvcc --version | tail -n 1 | cut -d" " -f2)"
+  echo " CUDAARCHS: $CUDAARCHS"
+fi
+echo "=================================================="
+echo ""
+


### PR DESCRIPTION
@AGonzalezNicolas you can use this branch to benchmark the GNU+ParaStationMPI combination:

```bash
./build_tsmp2.sh --eCLM --Parflow --env env/jsc.2025.gnu.psmpi
```