### PR TITLE
NVHPC toolchain support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "models/eCLM"]
 	path = models/eCLM
 	url = https://github.com/HPSCTerrSys/eCLM.git
-	branch = beta-0.4
+	branch = dev-nvhpc-support
 [submodule "models/oasis3-mct"]
         path = models/oasis3-mct
         url = https://icg4geo.icg.kfa-juelich.de/ExternalReposPublic/oasis3-mct

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "models/eCLM"]
 	path = models/eCLM
 	url = https://github.com/HPSCTerrSys/eCLM.git
-	branch = dev-nvhpc-support
+	branch = beta-0.5
 [submodule "models/oasis3-mct"]
         path = models/oasis3-mct
         url = https://icg4geo.icg.kfa-juelich.de/ExternalReposPublic/oasis3-mct

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = icon-2024.07-public_coup-oas
 [submodule "models/parflow"]
 	path = models/parflow
-	url = https://github.com/HPSCTerrSys/parflow.git
-	branch = fix-cuda13-api
+	url = https://github.com/parflow/parflow.git
+	branch = master
 [submodule "models/parflow_pdaf"]
 	path = models/parflow_pdaf
 	url = https://github.com/HPSCTerrSys/parflow

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = icon-2024.07-public_coup-oas
 [submodule "models/parflow"]
 	path = models/parflow
-	url = https://github.com/parflow/parflow.git
-	branch = v3.14.1
+	url = https://github.com/HPSCTerrSys/parflow.git
+	branch = fix-cuda13-api
 [submodule "models/parflow_pdaf"]
 	path = models/parflow_pdaf
 	url = https://github.com/HPSCTerrSys/parflow

--- a/cmake/BuildOASIS3MCT.cmake
+++ b/cmake/BuildOASIS3MCT.cmake
@@ -44,6 +44,9 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   file(APPEND  ${OASIS_MAKE_INC} "FCBASEFLAGS     = ${OPTIM} -I. -ffree-line-length-none -fallow-argument-mismatch ${OpenMP_Fortran_FLAGS}\n")
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" OR CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
   file(APPEND  ${OASIS_MAKE_INC} "FCBASEFLAGS     = ${OPTIM} -I. -xCORE-AVX2 -assume byterecl -mt_mpi ${OpenMP_Fortran_FLAGS}\n")
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
+  # nvfortran doesn't support real(16) / quad precision; hence the __NO_16BYTE_REALS here.
+  file(APPEND  ${OASIS_MAKE_INC} "FCBASEFLAGS     = -D__NO_16BYTE_REALS ${OPTIM} -I. ${OpenMP_Fortran_FLAGS}\n")
 else()
   message(FATAL_ERROR "Fortran compiler '${CMAKE_Fortran_COMPILER_ID}' is not supported.")
 endif()
@@ -68,7 +71,7 @@ ExternalProject_Add(OASIS3_MCT
   SOURCE_DIR        ${OASIS_SRC}
   BUILD_IN_SOURCE   FALSE
   CONFIGURE_COMMAND ""
-  BUILD_COMMAND     make -f ${OASIS_SRC}/util/make_dir/TopMakefileOasis3 static-libs -C ${OASIS_BLD_DIR}
+  BUILD_COMMAND     make -f ${OASIS_SRC}/util/make_dir/TopMakefileOasis3 realclean static-libs -C ${OASIS_BLD_DIR}
   INSTALL_COMMAND   ""
 )
 

--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -24,6 +24,7 @@ endif()
 # LAPACK is required
 # For eCLM-PDAF, this setting has to be consistent with MKL/LAPACK
 # loading in `eCLM/src/clm5/CMakelists.txt`
+# https://cmake.org/cmake/help/latest/module/FindLAPACK.html
 find_package(LAPACK REQUIRED)
 
 # OpenMP is required
@@ -73,6 +74,12 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   list(APPEND PDAF_LINK_LIBS "-mkl")
   list(APPEND PDAF_LINK_LIBS "${LAPACK_LIBRARIES}")
   message(WARNING "LAPACK_LIBRARIES: ${LAPACK_LIBRARIES}")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+  # MKL command
+  list(APPEND PDAF_LINK_LIBS "${LAPACK_LIBRARIES}")
+  list(APPEND PDAF_LINK_LIBS "${LAPACK_LINKER_FLAGS}")
+  message(STATUS "LAPACK_LIBRARIES: ${LAPACK_LIBRARIES}")
+  message(STATUS "LAPACK_LINKER_FLAGS: ${LAPACK_LINKER_FLAGS}")
 else()
   message(FATAL_ERROR "Unsupported CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
 endif()
@@ -147,6 +154,22 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   list(APPEND PDAF_FOPT "-fallow-argument-mismatch")
   list(APPEND PDAF_FOPT "-fcommon")
 
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+
+  # Using NVHPC
+  if (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+    # Release optimization flags
+    list(APPEND PDAF_FOPT "-Ofast")
+  elseif (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+    # Debug optimization flags
+    list(APPEND PDAF_FOPT "-O0")
+    list(APPEND PDAF_FOPT "-g")
+  else()
+    message(FATAL_ERROR "Unsupported CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+  endif()
+
+  list(APPEND PDAF_FOPT "-fPIC")
+
 else()
   message(FATAL_ERROR "Unsupported CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
 endif()
@@ -195,6 +218,22 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   list(APPEND PDAF_COPT "-mcmodel=large")
   list(APPEND PDAF_COPT "-fcommon")
 
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+
+  # Using NVHPC
+  if (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+    # Release optimization flags
+    list(APPEND PDAF_COPT "-Ofast")
+  elseif (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+    # Debug optimization flags
+    list(APPEND PDAF_COPT "-O0")
+    list(APPEND PDAF_COPT "-g")
+  else()
+    message(FATAL_ERROR "Unsupported CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+  endif()
+
+  list(APPEND PDAF_COPT "-fPIC")
+
 else()
   message(FATAL_ERROR "Unsupported CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
 endif()
@@ -212,6 +251,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
   list(APPEND PDAF_DOUBLEPRECISION "-fdefault-real-8")
+
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+
+  # doubleprecision flag!?
+  list(APPEND PDAF_DOUBLEPRECISION "-r8")
 
 else()
   message(FATAL_ERROR "Unsupported CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")

--- a/cmake/BuildParFlow.cmake
+++ b/cmake/BuildParFlow.cmake
@@ -35,7 +35,6 @@ else()
   else()
     set(PF_ACC_BACKEND "none") 
   endif()
-  #TODO: Add support for 'kokkos' backend
 endif()
 
 # Set compiler flags
@@ -48,7 +47,12 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
     set(PF_FFLAGS "-ffree-line-length-none -ffixed-line-length-none")
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel" OR CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
-    set(PF_CFLAGS "-Wall -Werror -Wno-unused-function -Wno-unused-variable")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "NVHPC")
+    if (NOT ${ParFlowGPU})
+      # TODO: Perhaps there's a case for using NVHPC to target CPU. This would require
+      #       fiddling with libraries+environment so we don't support it for now.
+      message(FATAL_ERROR "NVHPC is only valid for ParflowGPU builds.")
+    endif()
 else()
   message(FATAL_ERROR "C compiler '${CMAKE_C_COMPILER_ID}' is not supported.")
 endif()

--- a/cmake/BuildParFlow.cmake
+++ b/cmake/BuildParFlow.cmake
@@ -47,6 +47,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
     set(PF_FFLAGS "-ffree-line-length-none -ffixed-line-length-none")
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel" OR CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+    set(PF_CFLAGS "-Wall -Werror -Wno-unused-function -Wno-unused-variable")
 elseif(CMAKE_C_COMPILER_ID STREQUAL "NVHPC")
     if (NOT ${ParFlowGPU})
       # TODO: Perhaps there's a case for using NVHPC to target CPU. This would require

--- a/cmake/BuildParFlow.cmake
+++ b/cmake/BuildParFlow.cmake
@@ -66,6 +66,16 @@ else()
   set(ENABLE_SLURM "OFF")
 endif()
 
+# Enable Umpire if exists
+if (DEFINED ENV{UMPIRE_ROOT})
+  set(PF_UMPIRE_FLAG "-DUMPIRE_ROOT=$ENV{UMPIRE_ROOT}")
+endif()
+
+# Enable SUNDIALS if exists
+if (DEFINED ENV{SUNDIALS_ROOT})
+    set(PF_SUNDIALS_FLAG "-DSUNDIALS_ROOT=$ENV{SUNDIALS_ROOT}")
+endif()
+
 # Pass options to ParFlow CMake
 ExternalProject_Add(ParFlow
     PREFIX      ParFlow
@@ -85,6 +95,8 @@ ExternalProject_Add(ParFlow
                 -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
                 -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
                 -DPARFLOW_ENABLE_SLURM=${ENABLE_SLURM}
+                ${PF_UMPIRE_FLAG}
+                ${PF_SUNDIALS_FLAG}
                 ${PF_CLM_FLAGS}
     DEPENDS     ${MODEL_DEPENDENCIES}
 )

--- a/env/jsc.2025.intel.psmpi
+++ b/env/jsc.2025.intel.psmpi
@@ -22,6 +22,8 @@ else
   module load Intel
 fi
 module load ParaStationMPI
+module load ScaLAPACK/2.2.0-fb
+
 
 # Basic scripting and build tools
 module load Python

--- a/env/jsc.2025.nvhpc.openmpi
+++ b/env/jsc.2025.nvhpc.openmpi
@@ -26,12 +26,19 @@ module load netCDF
 module load netCDF-Fortran
 module load PnetCDF
 
-# ParFlow additional libraries (TODO)
-# module load Hypre # Non-existent under NVHPC toolchain
-# module load Tcl
-if [[ "$1" == "--parflowgpu" ]]; then
-  echo "ERROR: Hypre isn't yet available on the NVHPC toolchain."
+# ParFlow additional libraries
+module load CUDA
+module load UCX-settings/RC-CUDA
+module load Hypre/2.31.0
+
+# TODO: Verify these values
+if [[ $SYSTEMNAME == "jedi" || $SYSTEMNAME == "jupiter" ]]; then
+  export CUDAARCHS="90"
+else
+  export CUDAARCHS="80"
 fi
+export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
+
 
 # ICON additional libraries
 module load ecCodes
@@ -47,11 +54,11 @@ export MPI_HOME=$EBROOTOPENMPI
 
 # Display compiler settings
 module list
-echo "=============== COMPILER SETTINGS  ===============" 
+echo "=========================== COMPILER SETTINGS  =======================" 
 echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
 echo "   MPI lib: $(mpirun --version | head -n 1)"
 echo "         C: $($CC --version | head -n 2 | tail -n 1)"
 echo "       C++: $($CXX --version | head -n 2 | tail -n 1)"
 echo "   Fortran: $($FC --version | head -n 2 | tail -n 1)"
-echo "=================================================="
-echo ""
+echo "======================================================================"
+

--- a/env/jsc.2025.nvhpc.openmpi
+++ b/env/jsc.2025.nvhpc.openmpi
@@ -14,6 +14,7 @@ module use $OTHERSTAGES
 module load Stages/2025
 module load NVHPC/25.5-CUDA-12
 module load OpenMPI
+module load ScaLAPACK/2.2.0-fb
 
 # Basic scripting and build tools
 module load Python

--- a/env/jsc.2025.nvhpc.openmpi
+++ b/env/jsc.2025.nvhpc.openmpi
@@ -1,0 +1,57 @@
+# --------------------------------------------------------------------------
+# Loads IntelLLVM+ParaStationMPI build environment for TSMP2.
+# This environment is tailored for JURECA [1] and JUWELS [2] supercomputers.
+#
+# [1] https://apps.fz-juelich.de/jsc/software/jureca/index.xhtml
+# [2] https://apps.fz-juelich.de/jsc/software/juwels/index.xhtml
+# 
+# Usage: source jsc.2025.intel.psmpi
+# --------------------------------------------------------------------------
+
+# Load Stages/2025
+module --force purge
+module use $OTHERSTAGES
+module load Stages/2025
+module load NVHPC/25.5-CUDA-12
+module load OpenMPI
+
+# Basic scripting and build tools
+module load Python
+module load CMake
+module load git
+
+# Storage libraries
+module load HDF5
+module load netCDF
+module load netCDF-Fortran
+module load PnetCDF
+
+# ParFlow additional libraries (TODO)
+# module load Hypre # Non-existent under NVHPC toolchain
+# module load Tcl
+if [[ "$1" == "--parflowgpu" ]]; then
+  echo "ERROR: Hypre isn't yet available on the NVHPC toolchain."
+fi
+
+# ICON additional libraries
+module load ecCodes
+
+# Set default MPI compilers
+export OMPI_CC=nvc
+export OMPI_CXX=nvc++
+export OMPI_FC=nvfortran
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+export MPI_HOME=$EBROOTOPENMPI
+
+# Display compiler settings
+module list
+echo "=============== COMPILER SETTINGS  ===============" 
+echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
+echo "   MPI lib: $(mpirun --version | head -n 1)"
+echo "         C: $($CC --version | head -n 2 | tail -n 1)"
+echo "       C++: $($CXX --version | head -n 2 | tail -n 1)"
+echo "   Fortran: $($FC --version | head -n 2 | tail -n 1)"
+echo "=================================================="
+echo ""

--- a/env/jsc.2025.nvhpc.psmpi
+++ b/env/jsc.2025.nvhpc.psmpi
@@ -1,0 +1,54 @@
+# --------------------------------------------------------------------------
+# Loads IntelLLVM+ParaStationMPI build environment for TSMP2.
+# This environment is tailored for JURECA [1] and JUWELS [2] supercomputers.
+#
+# [1] https://apps.fz-juelich.de/jsc/software/jureca/index.xhtml
+# [2] https://apps.fz-juelich.de/jsc/software/juwels/index.xhtml
+# 
+# Usage: source jsc.2025.intel.psmpi
+# --------------------------------------------------------------------------
+
+# Load Stages/2025
+module --force purge
+module use $OTHERSTAGES
+module load Stages/2025
+module load NVHPC/25.5-CUDA-12
+module load ParaStationMPI
+
+# Basic scripting and build tools
+module load Python
+module load CMake
+module load git
+
+# Storage libraries
+module load HDF5
+module load netCDF
+module load netCDF-Fortran
+module load PnetCDF
+
+# ParFlow additional libraries (TODO)
+# module load Hypre # Non-existent under NVHPC toolchain
+# module load Tcl
+if [[ "$1" == "--parflowgpu" ]]; then
+  echo "ERROR: Hypre isn't yet available on the NVHPC toolchain."
+fi
+
+# ICON additional libraries
+module load ecCodes
+
+# Set default MPI compilers
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+export MPI_HOME=$EBROOTPSMPI
+
+# Display compiler settings
+module list
+echo "====================================== COMPILER SETTINGS ======================================"
+echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
+echo "   MPI lib: $(mpichversion | head -n 1 | tr -d =)"
+echo "         C: $($CC --version 2>/dev/null | head -n 2 | tail -n 1)"
+echo "       C++: $($CXX --version 2>/dev/null | head -n 2 | tail -n 1)"
+echo "   Fortran: $($FC --version 2>/dev/null | head -n 2 | tail -n 1)"
+echo "==============================================================================================="
+echo ""

--- a/env/jsc.2025.nvhpc.psmpi
+++ b/env/jsc.2025.nvhpc.psmpi
@@ -14,6 +14,7 @@ module use $OTHERSTAGES
 module load Stages/2025
 module load NVHPC/25.5-CUDA-12
 module load ParaStationMPI
+module load ScaLAPACK/2.2.0-fb
 
 # Basic scripting and build tools
 module load Python

--- a/env/jsc.2025.nvhpc.psmpi
+++ b/env/jsc.2025.nvhpc.psmpi
@@ -27,11 +27,17 @@ module load netCDF-Fortran
 module load PnetCDF
 
 # ParFlow additional libraries (TODO)
-# module load Hypre # Non-existent under NVHPC toolchain
-# module load Tcl
-if [[ "$1" == "--parflowgpu" ]]; then
-  echo "ERROR: Hypre isn't yet available on the NVHPC toolchain."
+module load CUDA
+module load UCX-settings/RC-CUDA
+module load Hypre/2.31.0
+
+# TODO: Verify these values
+if [[ $SYSTEMNAME == "jedi" || $SYSTEMNAME == "jupiter" ]]; then
+  export CUDAARCHS="90"
+else
+  export CUDAARCHS="80"
 fi
+export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
 
 # ICON additional libraries
 module load ecCodes
@@ -44,11 +50,11 @@ export MPI_HOME=$EBROOTPSMPI
 
 # Display compiler settings
 module list
-echo "====================================== COMPILER SETTINGS ======================================"
+echo "========================= COMPILER SETTINGS =========================="
 echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
 echo "   MPI lib: $(mpichversion | head -n 1 | tr -d =)"
 echo "         C: $($CC --version 2>/dev/null | head -n 2 | tail -n 1)"
 echo "       C++: $($CXX --version 2>/dev/null | head -n 2 | tail -n 1)"
 echo "   Fortran: $($FC --version 2>/dev/null | head -n 2 | tail -n 1)"
-echo "==============================================================================================="
+echo "======================================================================"
 echo ""

--- a/env/jsc.2026.gnu.openmpi
+++ b/env/jsc.2026.gnu.openmpi
@@ -1,0 +1,75 @@
+# --------------------------------------------------------------------------
+# Loads GNU+OpenMPI build environment for TSMP2.
+# This environment is tailored for JURECA [1] and JUWELS [2] supercomputers.
+#
+# [1] https://apps.fz-juelich.de/jsc/software/jureca/index.xhtml
+# [2] https://apps.fz-juelich.de/jsc/software/juwels/index.xhtml
+# 
+# Usage: source jsc.2026.gnu.openmpi
+# --------------------------------------------------------------------------
+
+# Load Stages/2026
+module --force purge
+module use $OTHERSTAGES
+module load Stages/2026
+
+# Primary compiler toolchain
+module load GCC
+module load OpenMPI
+
+# Basic scripting and build tools
+module load Python
+module load CMake
+module load git
+
+# Storage libraries
+module load HDF5
+module load netCDF
+module load netCDF-Fortran
+module load PnetCDF
+
+# ParFlow additional libraries
+if [[ "$1" == "--parflowgpu" ]]; then
+  module load CUDA
+  module load UCX-settings/RC-CUDA
+  module load Hypre/3.0.0
+
+  # TODO: Verify these values
+  if [[ $SYSTEMNAME == "jedi" || $SYSTEMNAME == "jupiter" ]]; then
+    export CUDAARCHS="90"
+  else
+    export CUDAARCHS="80"
+  fi
+  export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
+else
+  module load Hypre/3.0.0-cpu
+fi
+module load Tcl
+
+# ICON additional libraries
+module load ecCodes
+
+# Set default MPI compilers
+export OMPI_CC=gcc
+export OMPI_CXX=g++
+export OMPI_FC=gfortran
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+export MPI_HOME=$EBROOTOPENMPI
+
+# Display compiler settings
+module list
+echo "=============== COMPILER SETTINGS  ===============" 
+echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
+echo "   MPI lib: $(mpirun --version | head -n 1)"
+echo "         C: $($CC --version | head -n 1)"
+echo "       C++: $($CXX --version | head -n 1)"
+echo "   Fortran: $($FC --version | head -n 1)"
+if [[ "$1" == "--parflowgpu" ]]; then
+  echo "      nvcc: $(nvcc --version | tail -n 1 | cut -d" " -f2)"
+  echo " CUDAARCHS: $CUDAARCHS"
+fi
+echo "=================================================="
+echo ""
+

--- a/env/jsc.2026.nvhpc.openmpi
+++ b/env/jsc.2026.nvhpc.openmpi
@@ -31,6 +31,8 @@ module load PnetCDF/1.14.1
 module load CUDA
 module load UCX-settings/RC-CUDA
 module load Hypre
+module load Umpire
+module load SUNDIALS
 
 # TODO: Verify these values
 if [[ $SYSTEMNAME == "jupiter" ]]; then
@@ -45,13 +47,12 @@ export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
 module load ecCodes
 
 # Set default MPI compilers
-export OMPI_CC=nvc
-export OMPI_CXX=nvc++
-export OMPI_FC=nvfortran
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 export MPI_HOME=$EBROOTOPENMPI
+export UMPIRE_ROOT=$EBROOTUMPIRE
+export SUNDIALS_ROOT=$EBROOTSUNDIALS
 
 # Display compiler settings
 module list

--- a/env/jsc.2026.nvhpc.openmpi
+++ b/env/jsc.2026.nvhpc.openmpi
@@ -1,20 +1,20 @@
 # --------------------------------------------------------------------------
-# Loads IntelLLVM+ParaStationMPI build environment for TSMP2.
+# Loads NVHPC+OpenMPI build environment for TSMP2.
 # This environment is tailored for JURECA [1] and JUWELS [2] supercomputers.
 #
 # [1] https://apps.fz-juelich.de/jsc/software/jureca/index.xhtml
 # [2] https://apps.fz-juelich.de/jsc/software/juwels/index.xhtml
 # 
-# Usage: source jsc.2025.intel.psmpi
+# Usage: source jsc.2026.nvhpc.openmpi
 # --------------------------------------------------------------------------
 
-# Load Stages/2025
+# Load compilers and MPI library
 module --force purge
 module use $OTHERSTAGES
-module load Stages/2025
-module load NVHPC/25.5-CUDA-12
-module load ParaStationMPI
-module load ScaLAPACK/2.2.0-fb
+module load Stages/2026
+module load nvidia-compilers/25.9-CUDA-13
+module load OpenMPI
+module load ScaLAPACK
 
 # Basic scripting and build tools
 module load Python
@@ -23,39 +23,43 @@ module load git
 
 # Storage libraries
 module load HDF5
-module load netCDF
-module load netCDF-Fortran
-module load PnetCDF
+module load netCDF/4.9.3
+module load netCDF-Fortran/4.6.2
+module load PnetCDF/1.14.1
 
-# ParFlow additional libraries (TODO)
+# ParFlow additional libraries
 module load CUDA
 module load UCX-settings/RC-CUDA
-module load Hypre/2.31.0
+module load Hypre
 
 # TODO: Verify these values
-if [[ $SYSTEMNAME == "jedi" || $SYSTEMNAME == "jupiter" ]]; then
+if [[ $SYSTEMNAME == "jupiter" ]]; then
   export CUDAARCHS="90"
 else
   export CUDAARCHS="80"
 fi
 export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
 
+
 # ICON additional libraries
 module load ecCodes
 
 # Set default MPI compilers
+export OMPI_CC=nvc
+export OMPI_CXX=nvc++
+export OMPI_FC=nvfortran
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
-export MPI_HOME=$EBROOTPSMPI
+export MPI_HOME=$EBROOTOPENMPI
 
 # Display compiler settings
 module list
-echo "========================= COMPILER SETTINGS =========================="
+echo "=========================== COMPILER SETTINGS  =======================" 
 echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
-echo "   MPI lib: $(mpichversion | head -n 1 | tr -d =)"
-echo "         C: $($CC --version 2>/dev/null | head -n 2 | tail -n 1)"
-echo "       C++: $($CXX --version 2>/dev/null | head -n 2 | tail -n 1)"
-echo "   Fortran: $($FC --version 2>/dev/null | head -n 2 | tail -n 1)"
+echo "   MPI lib: OpenMPI v$EBVERSIONOPENMPI"
+echo "         C: $($CC --version | head -n 2 | tail -n 1)"
+echo "       C++: $($CXX --version | head -n 2 | tail -n 1)"
+echo "   Fortran: $($FC --version | head -n 2 | tail -n 1)"
 echo "======================================================================"
-echo ""
+

--- a/env/jsc.2026.nvhpc.psmpi
+++ b/env/jsc.2026.nvhpc.psmpi
@@ -1,20 +1,20 @@
 # --------------------------------------------------------------------------
-# Loads IntelLLVM+ParaStationMPI build environment for TSMP2.
+# Loads NVHPC+ParaStationMPI build environment for TSMP2.
 # This environment is tailored for JURECA [1] and JUWELS [2] supercomputers.
 #
 # [1] https://apps.fz-juelich.de/jsc/software/jureca/index.xhtml
 # [2] https://apps.fz-juelich.de/jsc/software/juwels/index.xhtml
 # 
-# Usage: source jsc.2025.intel.psmpi
+# Usage: source jsc.2026.nvhpc.psmpi
 # --------------------------------------------------------------------------
 
-# Load Stages/2025
+# Load compilers and MPI library
 module --force purge
 module use $OTHERSTAGES
-module load Stages/2025
-module load NVHPC/25.5-CUDA-12
-module load OpenMPI
-module load ScaLAPACK/2.2.0-fb
+module load Stages/2026
+module load nvidia-compilers/25.9-CUDA-13
+module load ParaStationMPI
+module load ScaLAPACK
 
 # Basic scripting and build tools
 module load Python
@@ -30,10 +30,10 @@ module load PnetCDF
 # ParFlow additional libraries
 module load CUDA
 module load UCX-settings/RC-CUDA
-module load Hypre/2.31.0
+module load Hypre
 
 # TODO: Verify these values
-if [[ $SYSTEMNAME == "jedi" || $SYSTEMNAME == "jupiter" ]]; then
+if [[ $SYSTEMNAME == "jupiter" ]]; then
   export CUDAARCHS="90"
 else
   export CUDAARCHS="80"
@@ -45,21 +45,18 @@ export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
 module load ecCodes
 
 # Set default MPI compilers
-export OMPI_CC=nvc
-export OMPI_CXX=nvc++
-export OMPI_FC=nvfortran
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
-export MPI_HOME=$EBROOTOPENMPI
+export MPI_HOME=$EBROOTPSMPI
 
 # Display compiler settings
 module list
 echo "=========================== COMPILER SETTINGS  =======================" 
 echo "   Machine: ${SYSTEMNAME} on Stages/$STAGE"
-echo "   MPI lib: $(mpirun --version | head -n 1)"
-echo "         C: $($CC --version | head -n 2 | tail -n 1)"
-echo "       C++: $($CXX --version | head -n 2 | tail -n 1)"
-echo "   Fortran: $($FC --version | head -n 2 | tail -n 1)"
+echo "   MPI lib: ParaStationMPI $EBVERSIONPSMPI"
+echo "         C: $($CC --version 2>/dev/null | head -n 2 | tail -n 1)"
+echo "       C++: $($CXX --version 2>/dev/null | head -n 2 | tail -n 1)"
+echo "   Fortran: $($FC --version 2>/dev/null | head -n 2 | tail -n 1)"
 echo "======================================================================"
 


### PR DESCRIPTION
This PR will add support for these toolchains:

1. **NVHPC+OpenMPI**: `env/jsc.2026.nvhpc.openmpi`
```
Currently Loaded Modules:
  1) Stages/2026                   (S)  28) SQLite/3.50.1        (H)  55) PnetCDF/1.14.1
  2) GCCcore/14.3.0                (H)  29) libffi/3.5.1         (H)  56) CUDA/13              (g)
  3) zlib/1.3.1                    (H)  30) Python/3.13.5             57) UCX-settings/RC-CUDA
  4) binutils/2.44                 (H)  31) libidn2/2.3.8             58) FFTW/3.3.10
  5) numactl/2.0.19                     32) libiconv/1.18        (H)  59) FFTW.MPI/3.3.10
  6) nvidia-compilers/25.9-CUDA-13 (g)  33) libunistring/1.3     (H)  60) camp/2025.12.0       (g)
  7) XZ/5.8.1                      (H)  34) libpsl/0.21.5             61) fmt/11.2.0
  8) libxml2/2.14.3                (H)  35) cURL/8.14.1               62) Umpire/2025.09.0     (g)
  9) libpciaccess/0.18.1           (H)  36) gzip/1.14            (H)  63) Hypre/3.0.0
 10) hwloc/2.12.1                  (g)  37) lz4/1.10.0           (H)  64) libpng/1.6.50        (H)
 11) OpenSSL/3                          38) zstd/1.5.7           (H)  65) libde265/1.0.16
 12) libevent/2.1.12               (H)  39) libarchive/3.8.1          66) x265/4.1             (H)
 13) UCX/default                   (g)  40) CMake/4.0.3               67) PCRE2/10.45
 14) PMIx/5.0.8                         41) expat/2.7.1          (H)  68) util-linux/2.41      (H)
 15) NCCL/default-CUDA-13          (g)  42) gettext/0.25         (H)  69) GLib/2.85.3          (H)
 16) UCC/default                   (g)  43) Perl/5.40.2               70) jbigkit/2.1          (H)
 17) MPI-settings/UCX                   44) git/2.50.1                71) libdeflate/1.24      (H)
 18) OpenMPI/5.0.8                      45) libaec/1.1.4              72) LibTIFF/4.7.0        (H)
 19) OpenBLAS/0.3.30                    46) HDF5/1.14.6               73) Brotli/1.1.0         (H)
 20) imkl/2025.2.0                      47) Blosc/1.21.6         (H)  74) freetype/2.13.3      (H)
 21) FlexiBLAS/3.4.5                    48) NASM/2.16.03         (H)  75) fontconfig/2.17.0    (H)
 22) ScaLAPACK/2.2.2-fb                 49) libjpeg-turbo/3.1.1  (H)  76) xorg-macros/1.20.2   (H)
 23) bzip2/1.0.8                   (H)  50) Blosc2/2.19.0             77) X11/20250608
 24) ncurses/6.5                   (H)  51) HDF5-plugins/1.14.6       78) Gdk-Pixbuf/2.42.12   (H)
 25) libreadline/8.2               (H)  52) Szip/2.1.1           (H)  79) libheif/1.20.2
 26) libtommath/1.3.0                   53) netCDF/4.9.3              80) JasPer/4.2.8         (H)
 27) Tcl/9.0.1                          54) netCDF-Fortran/4.6.2      81) ecCodes/2.44.0

  Where:
   S:  Module is Sticky, requires --force to unload or purge
   g:  Built with GPU support
   H:             Hidden Module

=========================== COMPILER SETTINGS  =======================
   Machine: jurecadc on Stages/2026
   MPI lib: OpenMPI v5.0.8
         C: nvc 25.9-0 64-bit target on x86-64 Linux -tp znver2 
       C++: nvc++ 25.9-0 64-bit target on x86-64 Linux -tp znver2 
   Fortran: nvfortran 25.9-0 64-bit target on x86-64 Linux -tp znver2 
======================================================================
```

2. **NVHPC+ParaStationMPI**: `env/jsc.2026.nvhpc.psmpi`

```
Currently Loaded Modules:
  1) Stages/2026                   (S)  29) SQLite/3.50.1        (H)  57) CUDA/13              (g)
  2) GCCcore/14.3.0                (H)  30) libffi/3.5.1         (H)  58) UCX-settings/RC-CUDA
  3) zlib/1.3.1                    (H)  31) Python/3.13.5             59) FFTW/3.3.10
  4) binutils/2.44                 (H)  32) libidn2/2.3.8             60) FFTW.MPI/3.3.10
  5) numactl/2.0.19                     33) libiconv/1.18        (H)  61) camp/2025.12.0       (g)
  6) nvidia-compilers/25.9-CUDA-13 (g)  34) libunistring/1.3     (H)  62) fmt/11.2.0
  7) UCX/default                   (g)  35) libpsl/0.21.5             63) Umpire/2025.09.0     (g)
  8) pscom/6-default               (H)  36) cURL/8.14.1               64) Hypre/3.0.0
  9) XZ/5.8.1                      (H)  37) gzip/1.14            (H)  65) libpng/1.6.50        (H)
 10) libxml2/2.14.3                (H)  38) lz4/1.10.0           (H)  66) libde265/1.0.16
 11) OpenSSL/3                          39) zstd/1.5.7           (H)  67) x265/4.1             (H)
 12) libevent/2.1.12               (H)  40) libarchive/3.8.1          68) PCRE2/10.45
 13) libpciaccess/0.18.1           (H)  41) CMake/4.0.3               69) util-linux/2.41      (H)
 14) hwloc/2.12.1                  (g)  42) expat/2.7.1          (H)  70) GLib/2.85.3          (H)
 15) PMIx/5.0.8                         43) gettext/0.25         (H)  71) jbigkit/2.1          (H)
 16) NCCL/default-CUDA-13          (g)  44) Perl/5.40.2               72) libdeflate/1.24      (H)
 17) UCC/default                   (g)  45) git/2.50.1                73) LibTIFF/4.7.0        (H)
 18) MPI-settings/UCX                   46) libaec/1.1.4              74) Brotli/1.1.0         (H)
 19) ParaStationMPI/5.13.0-1       (g)  47) HDF5/1.14.6               75) freetype/2.13.3      (H)
 20) OpenBLAS/0.3.30                    48) Blosc/1.21.6         (H)  76) fontconfig/2.17.0    (H)
 21) imkl/2025.2.0                      49) NASM/2.16.03         (H)  77) xorg-macros/1.20.2   (H)
 22) FlexiBLAS/3.4.5                    50) libjpeg-turbo/3.1.1  (H)  78) X11/20250608
 23) ScaLAPACK/2.2.2-fb                 51) Blosc2/2.19.0             79) Gdk-Pixbuf/2.42.12   (H)
 24) bzip2/1.0.8                   (H)  52) HDF5-plugins/1.14.6       80) libheif/1.20.2
 25) ncurses/6.5                   (H)  53) Szip/2.1.1           (H)  81) JasPer/4.2.8         (H)
 26) libreadline/8.2               (H)  54) netCDF/4.9.3              82) ecCodes/2.44.0
 27) libtommath/1.3.0                   55) netCDF-Fortran/4.6.2
 28) Tcl/9.0.1                          56) PnetCDF/1.14.1

  Where:
   S:  Module is Sticky, requires --force to unload or purge
   g:  Built with GPU support
   H:             Hidden Module

=========================== COMPILER SETTINGS  =======================
   Machine: jurecadc on Stages/2026
   MPI lib: ParaStationMPI 5.13.0-1
         C: nvc 25.9-0 64-bit target on x86-64 Linux -tp znver2 
       C++: nvc++ 25.9-0 64-bit target on x86-64 Linux -tp znver2 
   Fortran: nvfortran 25.9-0 64-bit target on x86-64 Linux -tp znver2 
======================================================================
```

## TODO

- [x] Request JSC-support to add an NVHPC-built Hypre
- [x] Add NVHPC support to eCLM
- [x] Fix [eCLM compile error](https://github.com/HPSCTerrSys/eCLM/pull/92#issuecomment-3602148515) when building in coupled mode
- [ ] Fix ParFlowGPU build error