### PR TITLE
Update BuildingTSMP2wCMake.md

### DIFF
--- a/docs/users_guide/building_TSMP2/BuildingTSMP2wCMake.md
+++ b/docs/users_guide/building_TSMP2/BuildingTSMP2wCMake.md
@@ -131,20 +131,20 @@ cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DeCLM=ON                               \
       -DICON=ON                               \
-      -DPARFLOW=ON
+      -DParFlow=ON
 
 # CLM3.5-COSMO5.01-ParFlow
 cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DCLM35=ON                              \
       -DCOSMO=ON                              \
-      -DPARFLOW=ON
+      -DParFlow=ON
 
 # CLM3.5-ParFlow
 cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DCLM35=ON                          \
-      -DPARFLOW=ON
+      -DParFlow=ON
 
 # CLM3.5-COSMO5.01
 cmake -S . -B ${BUILD_DIR}                    \
@@ -170,7 +170,7 @@ cmake -S . -B ${BUILD_DIR}                    \
 # ParFlow standalone
 cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
-      -DPARFLOW=ON
+      -DParFlow=ON
 
 #
 # For TSMP-PDAF builds, add -PDAF=ON
@@ -186,7 +186,7 @@ cmake -S . -B ${BUILD_DIR}                    \
 cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DCLM35=ON                              \
-      -DPARFLOW=ON                            \
+      -DParFlow=ON                            \
       -DPDAF=ON
 
 # eCLM-PDAF
@@ -199,7 +199,7 @@ cmake -S . -B ${BUILD_DIR}                    \
 cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DeCLM=ON                               \
-      -DPARFLOW=ON                            \
+      -DParFlow=ON                            \
       -DPDAF=ON
 
 ```

--- a/docs/users_guide/building_TSMP2/BuildingTSMP2wCMake.md
+++ b/docs/users_guide/building_TSMP2/BuildingTSMP2wCMake.md
@@ -124,7 +124,7 @@ cmake -S . -B ${BUILD_DIR}                    \
 cmake -S . -B ${BUILD_DIR}                    \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DeCLM=ON                               \
-      -DPARFLOW_SRC=ON
+      -DParFlow_SRC=ON
 
 # ICON-eCLM-ParFlow
 cmake -S . -B ${BUILD_DIR}                    \


### PR DESCRIPTION
Hello,

I've corrected the compiler macros in the description of the build of TSMP2 with -DPARFLOW to -DParFlow because ParFlow in capital letters don't work (cmake complains).
I tested it with ParFlow standalone, but I corrected it also for the other occurences of -DPARFLOW.