### PR TITLE
Include option input in autom_builds.sh

### DIFF
--- a/autom_builds.sh
+++ b/autom_builds.sh
@@ -22,6 +22,7 @@ fi
 
 combs=()
 envs=()
+options=""
 
 section=""
 
@@ -42,9 +43,15 @@ while IFS= read -r rawline; do
         continue
     fi
 
+    if [[ "$ULINE" == "OPTIONS:" ]]; then
+        section="options"
+        continue
+    fi
+
     case "$section" in
         "combinations") combs+=("$line") ;;
         "environments") envs+=("$line") ;;
+        "options") options+=" $line" ;;
     esac
 
 done < "$input_file"
@@ -69,7 +76,7 @@ for combo in "${combs[@]}"; do
 
         log_summary "START: combination=\"$combo\" environment=\"$env\""
 
-        cmd="./build_tsmp2.sh $combo_flags --env env/$env --force_update"
+        cmd="./build_tsmp2.sh $combo_flags --env env/$env --force_update $options"
 		log_summary "$cmd"
 
 		if eval "$cmd"; then

--- a/config_autom_builds.in
+++ b/config_autom_builds.in
@@ -12,3 +12,6 @@ ENVIRONMENTS:
 jsc.2025.intel.psmpi
 jsc.2025.gnu.openmpi
 jsc.2025.gnu.psmpi
+
+OPTIONS:
+--build_type RELEASE

--- a/readme_autom_builds.txt
+++ b/readme_autom_builds.txt
@@ -5,6 +5,8 @@ To use:
 This will create a matrix of builds with the components and environments specified in "config_autom_builds.in" file.
 For instance, if below components are: ICON, eCLM, ICON eCLM; and below environments: jsc.2025.intel.psmpi and jsc.2025.gnu.openmpi as:
 
+The optinos specified under `OPTIONS` will be used in the `./build_tsmp2.sh` command of each build in the matrix.
+
 #########################
 COMBINATIONS:
 ICON
@@ -14,6 +16,9 @@ ICON eCLM
 ENVIRONMENTS:
 jsc.2025.intel.psmpi
 jsc.2025.gnu.openmpi
+
+OPTIONS:
+--build_type RELEASE
 ################################
 
 It will build each combination twice (one for each environment).


### PR DESCRIPTION
Thinking about whether I could adopt this script for PDAF-testing, I would need a way to input more options to the `./build_tsmp2.sh` command. This could be another section in the configure file:
```
OPTIONS:
--build_type DEBUG
```

Maybe making things too general? However, I think it is minor changes in the scheme for maximal flexibility!