### PR TITLE
Add additional CLM3.5 option `--CLM3.5` in build-script

### DIFF
--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -22,7 +22,7 @@ function help_tsmp2() {
   echo "  --PDAF           Compile with PDAF"
   echo "  --COSMO          Compile with COSMO"
   echo "  --CLM35          Compile with CLM3.5"
-  echo "  --CLM3.5         Compile with CLM3.5"
+  echo "  --CLM3.5         Compile with CLM3.5 (same as option --CLM35)"
   echo "  --ICON_SRC       Set ICON_SRC directory"
   echo "  --eCLM_SRC       Set eCLM_SRC directory"
   echo "  --ParFlow_SRC    Set ParFlow_SRC directory"


### PR DESCRIPTION
Multiple times the difference between `--CLM35` and the model directory being called `CLM3.5` has caused disruption / errors.

Therefore, I suggest adding the option `--CLM3.5` for invoking CLM3.5.

Latest appearance of this issue, while checking out #109 (script is not renaming the build directory appropriately).

I tested it on JUWELS, where it works as expected. Only possible problem I see is that the `.` in `--CLM3.5` can cause problems / is highly unusual.