### PR TITLE
build_tsmp2: Interpret component model inputs as arguments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,35 +20,35 @@ jobs:
             name: "ICON-eCLM-ParFlow",
             use_oasis: "True",
             parflow_dir: "parflow",
-            model_opts: "--ICON --eCLM --ParFlow"
+            model_opts: "ICON eCLM ParFlow"
           }
         - {
             name: "eCLM-ParFlowGPU",
             use_oasis: "True",
             parflow_dir: "parflow",
-            model_opts: "--eCLM --ParFlowGPU"
+            model_opts: "eCLM ParFlowGPU"
           }
 #        - {
 #            name: "CLM3.5-PDAF",
 #            use_oasis: "False",
-#            model_opts: "--CLM35 --PDAF"
+#            model_opts: "CLM35 PDAF"
 #          }
         - {
             name: "eCLM-PDAF",
             use_oasis: "False",
-            model_opts: "--eCLM --PDAF"
+            model_opts: "eCLM PDAF"
           }
 #        - {
 #            name: "CLM3.5-ParFlow-PDAF",
 #            use_oasis: "True",
 #            parflow_dir: "parflow_pdaf",
-#            model_opts: "--CLM35 --ParFlow --PDAF"
+#            model_opts: "CLM35 ParFlow PDAF"
 #          }
 #        - {
 #            name: "eCLM-ParFlow-PDAF",
 #            use_oasis: "True",
 #            parflow_dir: "parflow_pdaf",
-#            model_opts: "--eCLM --ParFlow --PDAF"
+#            model_opts: "eCLM ParFlow PDAF"
 #         }
     env:
       SYSTEMNAME: UBUNTU

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -25,7 +25,7 @@ function help_tsmp2() {
   echo "  parflowGPU     Compile with ParFlow subsurface model (GPU-enabled)"
   echo "  pdaf           Compile with PDAF data assimilation framework."
   echo "  cosmo          Compile with COSMO atmosphere model (legacy)"
-  echo "  clm35          Compile with CLM3.5 land surface model (legacy)"
+  echo "  clm3.5          Compile with CLM3.5 land surface model (legacy)"
   echo ""
   echo "Options:"
   echo ""
@@ -127,7 +127,7 @@ while [[ "$#" -gt 0 ]]; do
     --parflowgpu|parflowgpu) parflow=y parflowGPU=y parflowCMakeModelID="ParFlowGPU";;
     --pdaf|pdaf) pdaf=y;;
     --cosmo|cosmo) cosmo=y;;
-    --clm35|clm35) clm35=y;;
+    --clm35|--clm3.5|clm3.5) clm35=y;;
     --no_update) update_compsrc=n;;
     --clean_first) clean_first=y;;
     --icon_src) icon_src="$2"; shift ;;

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -120,7 +120,7 @@ while [[ "$#" -gt 0 ]]; do
     -h|--help) help_tsmp2;;
     -q|--quiet) quiet=y;;
     -v|--verbose) verbose_makefile=y;;
-    --version) echo "$0 version 0.1.0"; exit 1;;
+    --version) echo "$0 version 0.2.0"; exit 0;;
     --icon|icon) icon=y;;
     --eclm|eclm) eclm=y;;
     --parflow|parflow) parflow=y parflowCPU=y parflowCMakeModelID="ParFlow";;

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ### TSMP2 frontend
-### Shell-based script to compile model components within the TSMP2 framework.
+### Bash script for compiling model components within the TSMP2 framework.
 ###
 ### For more information:
 ### ./build_tsmp2.sh --help
@@ -11,7 +11,7 @@ set -eo pipefail
 ## functions
 
 function help_tsmp2() {
-  echo "build_tsmp2.sh - Shell-based script to compile model components within the TSMP2 framework."
+  echo "build_tsmp2.sh - Bash script for compiling model components within the TSMP2 framework."
   echo ""
   echo "Usage:"
   echo ""
@@ -48,7 +48,8 @@ function help_tsmp2() {
   echo ""
   echo "  ./build_tsmp2.sh icon eclm parflow"
   echo "  ./build_tsmp2.sh eclm parflowGPU"
-  echo "  ./build_tsmp2.sh iconGPU eclm"
+  echo "  ./build_tsmp2.sh icon eclm"
+  echo "  ./build_tsmp2.sh eclm pdaf"
   echo ""
   exit 1
 }

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -123,7 +123,7 @@ while [[ "$#" -gt 0 ]]; do
     --version) echo "$0 version 0.1.0"; exit 1;;
     --icon|icon) icon=y;;
     --eclm|eclm) eclm=y;;
-    --parflow|parflow) parflow=y parflowCPU=n parflowCMakeModelID="ParFlow";;
+    --parflow|parflow) parflow=y parflowCPU=y parflowCMakeModelID="ParFlow";;
     --parflowgpu|parflowgpu) parflow=y parflowGPU=y parflowCMakeModelID="ParFlowGPU";;
     --pdaf|pdaf) pdaf=y;;
     --cosmo|cosmo) cosmo=y;;

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -11,18 +11,24 @@ set -eo pipefail
 ## functions
 
 function help_tsmp2() {
-  echo "Usage: $0 [-v ] [--component_name] [--optionals]"
-  echo "  -q, --quiet      Write less output during shell execution"
-  echo "  -v, --verbose    Enable verbose output from Makefile builds using CMAKE_VERBOSE_MAKEFILE"
-  echo "  --version        Print $0 scipt version"
-  echo "  --ICON           Compile with ICON"
-  echo "  --eCLM           Compile with eCLM"
-  echo "  --ParFlow        Compile with ParFlow (CPU mode)"
-  echo "  --ParFlowGPU     Compile with ParFlow (GPU mode)"
-  echo "  --PDAF           Compile with PDAF"
-  echo "  --COSMO          Compile with COSMO"
-  echo "  --CLM35          Compile with CLM3.5"
-  echo "  --CLM3.5         Compile with CLM3.5 (same as option --CLM35)"
+  echo "build_tsmp2.sh - Shell-based script to compile model components within the TSMP2 framework."
+  echo ""
+  echo "Usage:"
+  echo ""
+  echo "  ./build_tsmp2.sh [component models...] [options...]"
+  echo ""
+  echo "Component models:"
+  echo ""
+  echo "  icon           Compile with ICON atmosphere model."
+  echo "  eclm           Compile with eCLM land surface model."
+  echo "  parflow        Compile with ParFlow subsurface model."
+  echo "  parflowGPU     Compile with ParFlow subsurface model (GPU-enabled)"
+  echo "  pdaf           Compile with PDAF data assimilation framework."
+  echo "  cosmo          Compile with COSMO atmosphere model (legacy)"
+  echo "  clm35          Compile with CLM3.5 land surface model (legacy)"
+  echo ""
+  echo "Options:"
+  echo ""
   echo "  --ICON_SRC       Set ICON_SRC directory"
   echo "  --eCLM_SRC       Set eCLM_SRC directory"
   echo "  --ParFlow_SRC    Set ParFlow_SRC directory"
@@ -34,8 +40,16 @@ function help_tsmp2() {
   echo "  --install_dir    Set install dir cmake, if not set bin/<SYSTEMNAME>_<model-id> is used. Model executables and libraries will be installed here"
   echo "  --clean_first    Delete build_dir if it already exists"
   echo "  --env            Set model environment."
+  echo "  --version        Print $0 scipt version"
+  echo "  -q, --quiet      Write less output during shell execution"
+  echo "  -v, --verbose    Enable verbose output from Makefile builds using CMAKE_VERBOSE_MAKEFILE"
   echo ""
-  echo "Example: $0 --ICON --eCLM --ParFlow"
+  echo "Examples:"
+  echo ""
+  echo "  ./build_tsmp2.sh icon eclm parflow"
+  echo "  ./build_tsmp2.sh eclm parflowGPU"
+  echo "  ./build_tsmp2.sh iconGPU eclm"
+  echo ""
   exit 1
 }
 
@@ -99,19 +113,20 @@ fi # quiet
 ###
 
 ## get params
+# TODO: --<model> switches should be deprecated in favor of <model>
 while [[ "$#" -gt 0 ]]; do
   case "${1,,}" in
     -h|--help) help_tsmp2;;
     -q|--quiet) quiet=y;;
     -v|--verbose) verbose_makefile=y;;
-    --version) echo "$0 version 0.1.0"; exit 0;;
-    --icon) icon=y;;
-    --eclm) eclm=y;;
-    --parflow) parflow=y; parflowCPU=y; parflowCMakeModelID="ParFlow" ;;
-    --parflowgpu) parflow=y; parflowGPU=y; parflowCMakeModelID="ParFlowGPU" ;;
-    --pdaf) pdaf=y;;
-    --cosmo) cosmo=y;;
-    --clm35|--clm3.5) clm35=y;;
+    --version) echo "$0 version 0.1.0"; exit 1;;
+    --icon|icon) icon=y;;
+    --eclm|eclm) eclm=y;;
+    --parflow|parflow) parflow=y parflowGPU=n parflowCMakeModelID="ParFlow";;
+    --parflowgpu|parflowgpu) parflow=y parflowGPU=y parflowCMakeModelID="ParFlowGPU";;
+    --pdaf|pdaf) pdaf=y;;
+    --cosmo|cosmo) cosmo=y;;
+    --clm35|clm35) clm35=y;;
     --no_update) update_compsrc=n;;
     --clean_first) clean_first=y;;
     --icon_src) icon_src="$2"; shift ;;

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -25,7 +25,7 @@ function help_tsmp2() {
   echo "  parflowGPU     Compile with ParFlow subsurface model (GPU-enabled)"
   echo "  pdaf           Compile with PDAF data assimilation framework."
   echo "  cosmo          Compile with COSMO atmosphere model (legacy)"
-  echo "  clm3.5          Compile with CLM3.5 land surface model (legacy)"
+  echo "  clm3.5         Compile with CLM3.5 land surface model (legacy)"
   echo ""
   echo "Options:"
   echo ""

--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -123,7 +123,7 @@ while [[ "$#" -gt 0 ]]; do
     --version) echo "$0 version 0.1.0"; exit 1;;
     --icon|icon) icon=y;;
     --eclm|eclm) eclm=y;;
-    --parflow|parflow) parflow=y parflowGPU=n parflowCMakeModelID="ParFlow";;
+    --parflow|parflow) parflow=y parflowCPU=n parflowCMakeModelID="ParFlow";;
     --parflowgpu|parflowgpu) parflow=y parflowGPU=y parflowCMakeModelID="ParFlowGPU";;
     --pdaf|pdaf) pdaf=y;;
     --cosmo|cosmo) cosmo=y;;

--- a/docs/users_guide/building_TSMP2/Quickstart.md
+++ b/docs/users_guide/building_TSMP2/Quickstart.md
@@ -35,7 +35,7 @@ The component models (git submodules) are cloned during the execution of `build_
 ./build_tsmp2.sh ICON --ICON_SRC ${ICON_SRC}
 
 # Build ParFlow on Marvin (Uni Bonn)
-./build_tsmp2.sh ParFlow --env env/uni-bonn.gnu.openmpi parflow
+./build_tsmp2.sh ParFlow --env env/uni-bonn.gnu.openmpi
 
 
 # Fancy way of building a fully-coupled model

--- a/docs/users_guide/building_TSMP2/Quickstart.md
+++ b/docs/users_guide/building_TSMP2/Quickstart.md
@@ -48,6 +48,6 @@ eclm parflowgpu
 icon eclm
 eclm pdaf
 EOF
-cat model_combinations.txt | xargs -t -n 3 ./build_tsmp2.sh --no_update
+cat model_combinations.txt | xargs -t -L 1 ./build_tsmp2.sh --no_update
 ```
 

--- a/docs/users_guide/building_TSMP2/Quickstart.md
+++ b/docs/users_guide/building_TSMP2/Quickstart.md
@@ -36,10 +36,17 @@ The component models (git submodules) are cloned during the execution of `build_
 
 # Build ParFlow on Marvin (Uni Bonn)
 ./build_tsmp2.sh ParFlow --env env/uni-bonn.gnu.openmpi
+```
 
+## `build_tsmp2.sh` cheatsheet
 
-# Fancy way of building a fully-coupled model
-echo "eCLM ICON ParFlow" | xargs -t ./build_tsmp2.sh --no_update --clean_first
+```bash
+# Specify model combinations thru xargs
+echo "icon eclm parflow" | xargs -t ./build_tsmp2.sh --no_update --clean_first
+
+# Build models with custom environment, build, and install directories
+echo "icon eclm parflow" | xargs -t -L 1 ./build_tsmp2.sh --no_update --env env/jsc.2025.gnu.psmpi --build_dir bld/ICON_eCLM_ParFlow_GNUPSMPI --install_dir bin/ICON_eCLM_ParFlow_GNUPSMPI
+echo "eclm parflowgpu" | xargs -t -L 1 ./build_tsmp2.sh --no_update --env env/jsc.2025.gnu.openmpi --build_dir bld/eCLM_ParFlowGPU_GNUOPENMPI --install_dir bin/eCLM_ParFlowGPU_GNUOPENMPI
 
 # Build multiple combinations (useful for CI)
 cat << EOF > model_combinations.txt
@@ -49,5 +56,8 @@ icon eclm
 eclm pdaf
 EOF
 cat model_combinations.txt | xargs -t -L 1 ./build_tsmp2.sh --no_update
+
+# Force-update all component models before building
+yes y | ./build_tsmp2.sh icon eclm parflow
 ```
 

--- a/docs/users_guide/building_TSMP2/Quickstart.md
+++ b/docs/users_guide/building_TSMP2/Quickstart.md
@@ -13,32 +13,41 @@ cd TSMP2
 
 2. Build model components with TSMP2 framework
 
-To build a model component one need to activate the component model `--<COMP>`. The options are not case-sensitive and do not need to be in an specific order.
+To build a model component one need to activate the component model `<COMP>`. The options are not case-sensitive and do not need to be in an specific order.
 
 ```{note}
-The component models (git submodules) are cloned during the execution of `build_tsmp2.sh`. If the component model (`models/<COMP>`) are already exists, the user is asked if the folder should be overwritten or not. If you do want to use the default model component source codes, one can use the option `--<COMP_SRC>`.
+The component models (git submodules) are cloned during the execution of `build_tsmp2.sh`. If the component model (`models/<COMP>`) are already exists, the user is asked if the folder should be overwritten or not. If you do want to use the default model component source codes, one can use the option `<COMP_SRC>`.
 ```
 
 ```bash
 # to see options
 ./build_tsmp2.sh --help
 
-# ICON-eCLM-ParFlow
-./build_tsmp2.sh --ICON --eCLM --PARFLOW
+# Build the fully-coupled model (ICON-eCLM-ParFlow)
+./build_tsmp2.sh icon eclm parflow
 
-# eCLM-ParFlow
-./build_tsmp2.sh --eCLM --PARFLOW
+# Other possible model combinations
+./build_tsmp2.sh eclm parflow
+./build_tsmp2.sh icon eclm
+./build_tsmp2.sh eclm pdaf
 
-# ICON-eCLM
-./build_tsmp2.sh --ICON --eCLM
+# Build ICON from a local source repo
+./build_tsmp2.sh ICON --ICON_SRC ${ICON_SRC}
 
-# eCLM-PDAF
-./build_tsmp2.sh --eCLM --PDAF
+# Build ParFlow on Marvin (Uni Bonn)
+./build_tsmp2.sh ParFlow --env env/uni-bonn.gnu.openmpi parflow
 
-# ICON (with source code)
-./build_tsmp2.sh --ICON --ICON_SRC ${ICON_SRC}
 
-# ParFlow on Marvin (Uni Bonn)
-./build_tsmp2.sh --ParFlow --env env/uni-bonn.gnu.openmpi
+# Fancy way of building a fully-coupled model
+echo "eCLM ICON ParFlow" | xargs -t ./build_tsmp2.sh --no_update --clean_first
+
+# Build multiple combinations (useful for CI)
+cat << EOF > model_combinations.txt
+icon eclm parflow
+eclm parflowgpu
+icon eclm
+eclm pdaf
+EOF
+cat model_combinations.txt | xargs -t -n 3 ./build_tsmp2.sh --no_update
 ```
 


### PR DESCRIPTION
Inspired by @AGonzalezNicolas's matrix builds (#109). With this change this becomes possible:

```bash
./build_tsmp2.sh icon eclm parflow
echo "eCLM ICON ParFlow" | xargs -t ./build_tsmp2.sh --no_update

cat << EOF > model_combinations.txt
icon eclm parflow
eclm parflowgpu
icon
EOF
cat model_combinations.txt | xargs -t -L 1 ./build_tsmp2.sh --no_update
```