### PR TITLE
Add UCX-settings/DC module loading for jupiter

### DIFF
--- a/env/jsc.2025.gnu.openmpi
+++ b/env/jsc.2025.gnu.openmpi
@@ -43,6 +43,9 @@ if [[ "$1" == "--parflowgpu" ]]; then
   export CMAKE_CUDA_RUNTIME_LIBRARY="Shared"
 else
   module load Hypre/2.31.0-cpu
+  if [[ $SYSTEMNAME == "jupiter" ]]; then
+    module load UCX-settings/DC
+  fi
 fi
 module load Tcl
 


### PR DESCRIPTION
Load UCX-settings/DC module for jupiter system.
When more than one node is involved to run the simulation it needs to upload this module.