### PR TITLE
Release PDAF with -fp-model=source for consistent LESTKF results

### DIFF
--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -105,6 +105,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
   if (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
     # Release optimization flags
     list(APPEND PDAF_FOPT "-O2")
+    list(APPEND PDAF_FOPT "-fp-model=precise")
   elseif (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
     # Debug optimization flags
     list(APPEND PDAF_FOPT "-O0")

--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -105,7 +105,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
   if (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
     # Release optimization flags
     list(APPEND PDAF_FOPT "-O2")
-    list(APPEND PDAF_FOPT "-fp-model=precise")
+    # Adding `-fp-model=source` to avoid precision changes between
+    # DEBUG and RELEASE simulations
+    #
+    # Background, why `source` is chosen over `precise`:
+    # https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html
+    list(APPEND PDAF_FOPT "-fp-model=source")
   elseif (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
     # Debug optimization flags
     list(APPEND PDAF_FOPT "-O0")


### PR DESCRIPTION
Addresses PDAF issue: 
- HPSCTerrSys/pdaf#75

Turning on `-fp-model=source` in `RELEASE` build for consistent LESTKF results.

## Possible drawback

Performance loss. (so far not noticed in re-running existing experiments)

## Further information
- https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2023-0/fp-model-fp.html