### PR TITLE
Skip cosmo5.01_fresh and CLM3.5 during recursive submodule clone

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -381,7 +381,7 @@ jobs:
         name: Update CLM3.5 submodule ${{ steps.model-versions.outputs.VER_CLM35 }}
         working-directory: ${{ env.TSMP2_ROOT }}/models/CLM3.5
         run: |
-          pwd && git submodule update --init --force .
+          pwd && git submodule update --init --checkout --force .
 
       #
       # ParFlow

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,4 @@
 	path = models/cosmo5.01_fresh
 	url = https://gitlab.jsc.fz-juelich.de/sdlts/tsmp_components_mirrors/cosmo5.01_fresh.git
 	branch = tsmp-oasis
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,9 +26,9 @@
 	path = models/CLM3.5
 	url = https://github.com/HPSCTerrSys/CLM3.5.git
 	branch = tsmp-patches-v0.4
-        active = false
+        update = none
 [submodule "models/cosmo5.01_fresh"]
 	path = models/cosmo5.01_fresh
 	url = https://gitlab.jsc.fz-juelich.de/sdlts/tsmp_components_mirrors/cosmo5.01_fresh.git
 	branch = tsmp-oasis
-        active = false
+        update = none

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,7 @@
 	path = models/CLM3.5
 	url = https://github.com/HPSCTerrSys/CLM3.5.git
 	branch = tsmp-patches-v0.4
+	shallow = true
 [submodule "models/cosmo5.01_fresh"]
 	path = models/cosmo5.01_fresh
 	url = https://gitlab.jsc.fz-juelich.de/sdlts/tsmp_components_mirrors/cosmo5.01_fresh.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,9 +26,9 @@
 	path = models/CLM3.5
 	url = https://github.com/HPSCTerrSys/CLM3.5.git
 	branch = tsmp-patches-v0.4
-	shallow = true
+        active = false
 [submodule "models/cosmo5.01_fresh"]
 	path = models/cosmo5.01_fresh
 	url = https://gitlab.jsc.fz-juelich.de/sdlts/tsmp_components_mirrors/cosmo5.01_fresh.git
 	branch = tsmp-oasis
-	shallow = true
+        active = false


### PR DESCRIPTION
`models/cosmo5.01_fresh` points to a repository that require authentication. Because of that, `git clone --recurse-submodules` and `git submodule update --init --recursive` fail (or hang waiting for password) for anyone who doesn't have credentials for this mirror, even if they don't need this component. 

I would suggest that in this case the TSMP1 components (COSMO and CLM3.5) are not cloned to avoid confusion.

If one specifically need cosmo5.01_fresh or CLM3.5, one can still clone these repositories:

git submodule update --init models/cosmo5.01_fresh
or
git submodule update --init models/CLM3.5